### PR TITLE
Fix highlighting of HTML code

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (options) {
     var $ = cheerio.load(str);
     $('code').each(function (index, code) {
       if (!$(code).hasClass('nohighlight')) {
-        $(code).html(hljs.highlightAuto($(code).text()).value);
+        $(code).html(hljs.highlightAuto($(code).html()).value);
       }
     });
     return $.html() || str;

--- a/test.js
+++ b/test.js
@@ -40,3 +40,22 @@ it('should not highlight', function (cb) {
 
   stream.end();
 });
+
+it('should highlight html', function (cb) {
+  var stream = highlight();
+
+  stream.on('data', function (file) {
+    assert.equal(file.relative, 'file.ext');
+    assert.equal(file.contents.toString(), '<code>&lt;<span class="hljs-keyword">div</span>&gt;html&lt;/<span class="hljs-keyword">div</span>&gt;</code>');
+  });
+
+  stream.on('end', cb);
+
+  stream.write(new gutil.File({
+    base: __dirname,
+    path: 'file.ext',
+    contents: new Buffer('<code><div>html</div></code>')
+  }));
+
+  stream.end();
+})


### PR DESCRIPTION
Currently, the gulp plugin isn't properly highlighting HTML code.

```html
<code>
  <a href="#">Default</a>
</code>
```
produces

```html
<code>
  <span class="hljs-keyword">Default</span>
</code>
```
instead of
```html
<code>
  <span class="hljs-tag">&lt;<span class="hljs-title">a</span> <span class="hljs-attribute">href</span>=<span class="hljs-value">"#"</span>&gt;</span>Default<span class="hljs-tag">&lt;/<span class="hljs-title">a</span>&gt;</span>
</code>
```

This is because the contents of the code block are being read out using $.text() instead of $.html(), so it's only using the text content of each node.