### PR TITLE
add option to cheerio to prevent issue with quotations becoming &quot;

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,18 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var cheerio = require('cheerio');
 var hljs = require('highlight.js');
+var _ = require('lodash');
+
+var DEFAULTS = {
+  cheerio: {
+    decodeEntities: false
+  }
+};
 
 module.exports = function (options) {
-  var highlight = function (str) {
-    var $ = cheerio.load(str, {decodeEntities: false});
+  var options = _.assign(DEFAULTS, options);
+  var highlight = function (str, options) {
+    var $ = cheerio.load(str, options.cheerio);
     $('code').each(function (index, code) {
       if (!$(code).hasClass('nohighlight')) {
         $(code).html(hljs.highlightAuto($(code).html()).value);
@@ -26,7 +34,7 @@ module.exports = function (options) {
     }
 
     try {
-      file.contents = new Buffer(highlight(file.contents.toString()), options);
+      file.contents = new Buffer(highlight(file.contents.toString(), options), options.buffer);
     } catch (err) {
       this.emit('error', new gutil.PluginError('gulp-highlight', err));
     }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var hljs = require('highlight.js');
 
 module.exports = function (options) {
   var highlight = function (str) {
-    var $ = cheerio.load(str);
+    var $ = cheerio.load(str, {decodeEntities: false});
     $('code').each(function (index, code) {
       if (!$(code).hasClass('nohighlight')) {
         $(code).html(hljs.highlightAuto($(code).html()).value);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "cheerio": "~0.19.0",
     "gulp-util": "~3.0.4",
-    "highlight.js": "~8.7.0",
+    "highlight.js": "~8.4.0",
     "lodash": "^3.10.1",
     "through2": "~0.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "gulpplugin highlightjs code syntax"
   ],
   "dependencies": {
+    "cheerio": "~0.19.0",
     "gulp-util": "~3.0.4",
-    "through2": "~0.6.3",
     "highlight.js": "~8.4.0",
-    "cheerio": "~0.19.0"
+    "lodash": "^3.10.1",
+    "through2": "~0.6.3"
   },
   "devDependencies": {
     "mocha": "*"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "cheerio": "~0.19.0",
     "gulp-util": "~3.0.4",
-    "highlight.js": "~8.4.0",
+    "highlight.js": "~8.7.0",
     "lodash": "^3.10.1",
     "through2": "~0.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-util": "~3.0.4",
     "through2": "~0.6.3",
     "highlight.js": "~8.4.0",
-    "cheerio": "~0.18.0"
+    "cheerio": "~0.19.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/test.js
+++ b/test.js
@@ -58,4 +58,23 @@ it('should highlight html', function (cb) {
   }));
 
   stream.end();
-})
+});
+
+it('should not HTML encode quotations', function (cb) {
+  var stream = highlight();
+
+  stream.on('data', function (file) {
+    assert.equal(file.relative, 'file.ext');
+    assert.equal(file.contents.toString(), '<code class="json"><span class="hljs-string">"dependencies"</span>: { <span class="hljs-string">"gulp-highlight"</span>: <span class="hljs-string">"^1.0.0"</span> }</code>');
+  });
+
+  stream.on('end', cb);
+
+  stream.write(new gutil.File({
+    base: __dirname,
+    path: 'file.ext',
+    contents: new Buffer('<code class="json">"dependencies": { "gulp-highlight": "^1.0.0" }</code>')
+  }));
+
+  stream.end();
+});


### PR DESCRIPTION
Hi Johannes!

Feel free to only merge this PR if you feel that it is acceptable. 

I was running into an issue where my html:

``` html
<code class="json">"dependencies": { "gulp-highlight": "^1.0.0" }</code>
```

was displaying as:

``` html
&quot;dependencies&quot;: { &quot;gulp-highlight&quot;: &quot;^1.0.0&quot; }
```

I wrote a test that will fail if you remove the option `{decodeEntities: false}` that I added. Let me know if I am simply just doing something wrong!