### PR TITLE
Added hljs class, selector and ignoreClass options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,18 +6,22 @@ var hljs = require('highlight.js');
 var assign = require('lodash.assign');
 
 var DEFAULTS = {
+  selector: 'code',
+  ignoreClass: 'nohighlight',
   cheerio: {
     decodeEntities: false
   }
 };
 
 module.exports = function (options) {
-  var options = assign(DEFAULTS, options);
+  var options = assign({}, DEFAULTS, options);
   var highlight = function (str, options) {
     var $ = cheerio.load(str, options.cheerio);
-    $('code').each(function (index, code) {
-      if (!$(code).hasClass('nohighlight')) {
-        $(code).html(hljs.highlightAuto($(code).html()).value);
+    $(options.selector).each(function (index, code) {
+      var elem = $(code);
+      if (!elem.hasClass(options.ignoreClass)) {
+        elem.html(hljs.highlightAuto(elem.html()).value);
+        elem.addClass('hljs');
       }
     });
     return $.html() || str;

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "gulpplugin highlightjs code syntax"
   ],
   "dependencies": {
-    "cheerio": "~0.19.0",
-    "gulp-util": "~3.0.4",
-    "highlight.js": "^9.0.0",
-    "lodash.assign": "^3.2.0",
-    "through2": "~0.6.3"
+    "cheerio": "~0.22.0",
+    "gulp-util": "~3.0.8",
+    "highlight.js": "^9.9.0",
+    "lodash.assign": "^4.2.0",
+    "through2": "~2.0.3"
   },
   "devDependencies": {
     "mocha": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-highlight",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "license": "MIT",
   "repository": "http://github.com/johannestroeger/gulp-highlight",

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ it('should highlight', function(cb) {
 
   stream.on('data', function(file) {
     assert.equal(file.relative, 'file.ext');
-    assert.equal(file.contents.toString(), '<code>* { <span class="hljs-attribute">box-sizing</span>: border-box }</code>');
+    assert.equal(file.contents.toString(), '<code class="hljs">* { <span class="hljs-attribute">box-sizing</span>: border-box }</code>');
   });
 
   stream.on('end', cb);
@@ -46,7 +46,7 @@ it('should highlight html', function(cb) {
 
   stream.on('data', function(file) {
     assert.equal(file.relative, 'file.ext');
-    assert.equal(file.contents.toString(), '<code>&lt;<span class="hljs-keyword">div</span>&gt;html&lt;/<span class="hljs-keyword">div</span>&gt;</code>');
+    assert.equal(file.contents.toString(), '<code class="hljs">&lt;<span class="hljs-keyword">div</span>&gt;html&lt;/<span class="hljs-keyword">div</span>&gt;</code>');
   });
 
   stream.on('end', cb);
@@ -65,7 +65,7 @@ it('should not HTML encode quotations', function(cb) {
 
   stream.on('data', function(file) {
     assert.equal(file.relative, 'file.ext');
-    assert.equal(file.contents.toString(), '<code class="json"><span class="hljs-string">"dependencies"</span>: { <span class="hljs-string">"gulp-highlight"</span>: <span class="hljs-string">"^1.0.0"</span> }</code>');
+    assert.equal(file.contents.toString(), '<code class="json hljs"><span class="hljs-string">"dependencies"</span>: { <span class="hljs-string">"gulp-highlight"</span>: <span class="hljs-string">"^1.0.0"</span> }</code>');
   });
 
   stream.on('end', cb);
@@ -74,6 +74,48 @@ it('should not HTML encode quotations', function(cb) {
     base: __dirname,
     path: 'file.ext',
     contents: new Buffer('<code class="json">"dependencies": { "gulp-highlight": "^1.0.0" }</code>')
+  }));
+
+  stream.end();
+});
+
+it('should highlight the custom selector only', function(cb) {
+  var stream = highlight({
+    selector: 'pre code'
+  });
+
+  stream.on('data', function(file) {
+    assert.equal(file.relative, 'file.ext');
+    assert.equal(file.contents.toString(), '<code class="css">* { box-sizing: border-box }</code><pre><code class="css hljs">* { <span class="hljs-attribute">box-sizing</span>: border-box }</code></pre>');
+  });
+
+  stream.on('end', cb);
+
+  stream.write(new gutil.File({
+    base: __dirname,
+    path: 'file.ext',
+    contents: new Buffer('<code class="css">* { box-sizing: border-box }</code><pre><code class="css">* { box-sizing: border-box }</code></pre>')
+  }));
+
+  stream.end();
+});
+
+it('should ignore a custom class', function(cb) {
+  var stream = new highlight({
+    ignoreClass: 'ignore-this'
+  });
+
+  stream.on('data', function(file) {
+    assert.equal(file.relative, 'file.ext');
+    assert.equal(file.contents.toString(), '<code class="css ignore-this">* { box-sizing: border-box }</code><code class="css hljs">* { <span class="hljs-attribute">box-sizing</span>: border-box }</code>');
+  });
+
+  stream.on('end', cb);
+
+  stream.write(new gutil.File({
+    base: __dirname,
+    path: 'file.ext',
+    contents: new Buffer('<code class="css ignore-this">* { box-sizing: border-box }</code><code class="css">* { box-sizing: border-box }</code>')
   }));
 
   stream.end();


### PR DESCRIPTION
- Added `hljs` class to resulting code block, from #4.
- Added `selector` option so you can do stuff like only highlight `pre code` blocks.
- Updated all dependencies.
- Fixed defaults assignment bug where user changes would be saved to `DEFAULTS` between runs.
- Added/updated tests to match changes.

Thanks!